### PR TITLE
feat(verbose): print the exit map

### DIFF
--- a/src/clink.rs
+++ b/src/clink.rs
@@ -20,6 +20,10 @@ impl Clink {
         let mut finder = LinkFinder::new();
         finder.kinds(&[LinkKind::Url]);
 
+        if config.verbose {
+            println!("Exit map: {exit_map:#?}")
+        }
+
         Clink {
             config,
             exit_map,
@@ -256,6 +260,7 @@ mod find_and_replace {
             sleep_duration: 150,
             params: HashSet::from(["foo".into()]),
             exit: vec![],
+            verbose: false,
         });
         assert_eq!(
             clink.find_and_replace("https://test.test/?foo=dsadsa",),

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,6 +44,8 @@ pub struct ClinkConfig {
     pub sleep_duration: u64,
     pub params: HashSet<Rc<str>>,
     pub exit: Vec<Vec<Rc<str>>>,
+    #[serde(skip)]
+    pub verbose: bool,
 }
 
 impl ClinkConfig {
@@ -54,6 +56,7 @@ impl ClinkConfig {
             sleep_duration: 150,
             params: get_default_params(),
             exit: get_default_exit(),
+            verbose: false,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,8 @@ fn main() -> Result<(), confy::ConfyError> {
 
     let config_path = PathBuf::from(args.config);
 
-    let cfg: ClinkConfig = load_config(&config_path);
+    let mut cfg: ClinkConfig = load_config(&config_path);
+    cfg.verbose = args.verbose;
 
     if !config_path.is_file() {
         confy::store_path(&config_path, &cfg)?;


### PR DESCRIPTION
Print the exit map when the verbose mode is enabled

I know there's a shortest way to do this(we can just make `build_exit_map` public and call it from the main function), but I took this way because I thought that we maybe wanted to track other things inside the `clank` instance, like the `process_query` method maybe?

- Closes: #102 