### PR TITLE
Add systemd user service unit file

### DIFF
--- a/contrib/clink.service
+++ b/contrib/clink.service
@@ -1,0 +1,28 @@
+[Unit]
+Description=Clean links copied to clipboard
+Documentation=https://github.com/Lurk/clink?tab=readme-ov-file#readme
+
+[Service]
+ExecStart=/usr/bin/clink
+# Sandboxing and other hardening
+NoNewPrivileges=yes
+ProtectProc=noaccess
+SystemCallFilter=@system-service
+SystemCallArchitectures=native
+ProtectSystem=strict
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectHostname=yes
+ProtectClock=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+RestrictAddressFamilies=AF_UNIX
+RestrictFileSystems=~@privileged-api
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+RestrictRealtime=yes
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Note that older versions of systemd may complain about some of the options in the unit file, as they can’t be effectuated by user units (currently). As of systemd 255 at least non-effective options should just be silently ignored.

Most importantly is probably the blocking of the ability to access the internet (not granting access to address families `AF_INET`/`AF_INET6`) so maliciously crafted links cannot call home or similar (in case there’s some undiscovered security issue in `clink`).

Fixes https://github.com/Lurk/clink/issues/5